### PR TITLE
Fixed buttons group in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Fluent::buttons([
     \Fluent::iconlink(Fluent::FA_REMOVE, action('Admin\UsersController@delete', $user->id), 'Delete')
         ->css('btn-sm btn-danger')
         ->data('confirm', 'Are you sure?')
-]])
+])
 ```
 
 ###Tabs


### PR DESCRIPTION
Somehow the ##license section is modified when online edited the readme file. Didn't actually do that.
