### PR TITLE
Fixed problem with attribute with value of "0"

### DIFF
--- a/src/Base/Control.php
+++ b/src/Base/Control.php
@@ -52,6 +52,16 @@ abstract class Control
 
         return array_filter($options, function($item)
         {
+            if (is_string($item))
+            {
+                return mb_strlen($item) > 0;
+            }
+
+            if (is_int($item))
+            {
+                return strlen($item) === strlen((int)$item);
+            }
+
             return !empty($item) && !is_array($item) && !is_object($item);
         });
     }


### PR DESCRIPTION
This is a fix for a problem with set value equals zero for attributes like "min" or "max". When in code is set to "0" for attribute "min" or "max", this attributes are not rendered. Eg:

`{!! FluentForm::group()->large(4, 2)->number('settings[S]')->step(1)->min(0) !!}`
gives:
`<input step="1" class="form-control" type="number" name="settings[S]" aria-required="true">`
expected:
`<input min="0" step="1" class="form-control" type="number" name="settings[S]" aria-required="true">`